### PR TITLE
Use anonymous reference __ for implicit external links that share text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ performance with openMP.
 Documentation (WIP): https://nupyprop.readthedocs.io/en/latest/
 
 **Note:** While the documentation is currently WIP, users and developers should consult the 
-`nuPyProp tutorial repository <https://research-git.uiowa.edu/spatel31/nupyprop_tutorial>`_
+`nuPyProp tutorial repository <https://research-git.uiowa.edu/spatel31/nupyprop_tutorial>`__
 for visualizing output from the code and creating user-defined models.
 
 Installation
@@ -127,7 +127,7 @@ Model Tables
    |                   nCTEQ15                  | `Phys. Rev. D 93, 085037 <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.93.085037>`_,   |
    |                                            | `Phys. Rev. D 81, 114012 <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.81.114012>`_    |
    +--------------------------------------------+--------------------------------------------------------------------------------------------------+
-   |                User Defined                | See `nuPyProp tutorial repository <https://github.com/sameer-patel-1/nupyprop_tutorial>`_        |
+   |                User Defined                | See `nuPyProp tutorial repository <https://github.com/sameer-patel-1/nupyprop_tutorial>`__       |
    +--------------------------------------------+--------------------------------------------------------------------------------------------------+
    
 
@@ -149,7 +149,7 @@ Model Tables
    |     Capella, Kaidalov, Merino, Tran (CKMT)    | `Eur. Phys. J. C 10, 153 <https://arxiv.org/abs/hep-ph/9806367>`_                              |
    |                                               | `Phys. Rev. D 63, 094020 <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.63.094020>`_  |
    +-----------------------------------------------+------------------------------------------------------------------------------------------------+
-   |                  User Defined                 | See `nuPyProp tutorial repository <https://github.com/sameer-patel-1/nupyprop_tutorial>`_      |
+   |                  User Defined                 | See `nuPyProp tutorial repository <https://github.com/sameer-patel-1/nupyprop_tutorial>`__     |
    +-----------------------------------------------+------------------------------------------------------------------------------------------------+
 
 Code Execution Timing Tables


### PR DESCRIPTION
Previous version added a link target named "nuPyProp tutorial repository" multiple times, and assigned it multiple (identical) values. In this case the rst specification thinks you're trying to perform a duplicate assignment so it throws a warning. twine won't allow imperfect rst code uploaded to pypi so the upload step fails. Fixed by using rst anonymous references (double underscore) instead, to behave like markdown style hyperlinks. Another solution would have been to include the target in a separate callout scope like this: https://docutils.sourceforge.io/docs/user/rst/quickref.html#external-hyperlink-targets